### PR TITLE
Added end of job listener

### DIFF
--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -3,28 +3,25 @@ package hello;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 @SpringBootApplication
-public class Application implements CommandLineRunner {
+public class Application {
 
-    public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
-    }
+    public static void main(String[] args) throws Exception {
+        ApplicationContext ctx = SpringApplication.run(Application.class, args);
 
-    @Autowired
-    JdbcTemplate jdbcTemplate;
+        CountDownLatch countDownLatch = ctx.getBean(CountDownLatch.class);
 
-    @Override
-    public void run(String... strings) throws Exception {
+        countDownLatch.await();
 
-        List<Person> results = jdbcTemplate.query("SELECT first_name, last_name FROM people", new RowMapper<Person>() {
+        List<Person> results = ctx.getBean(JdbcTemplate.class).query("SELECT first_name, last_name FROM people", new RowMapper<Person>() {
             @Override
             public Person mapRow(ResultSet rs, int row) throws SQLException {
                 return new Person(rs.getString(1), rs.getString(2));

--- a/complete/src/main/java/hello/JobCompletionNotificationListener.java
+++ b/complete/src/main/java/hello/JobCompletionNotificationListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hello;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListenerSupport;
+import org.springframework.util.Assert;
+
+/**
+ * @author Michael Minella
+ */
+public class JobCompletionNotificationListener extends JobExecutionListenerSupport {
+
+	private CountDownLatch countDownLatch;
+
+	public JobCompletionNotificationListener(CountDownLatch countDownLatch) {
+		Assert.notNull(countDownLatch);
+
+		this.countDownLatch = countDownLatch;
+	}
+
+	@Override
+	public void afterJob(JobExecution jobExecution) {
+		if(jobExecution.getStatus() == BatchStatus.COMPLETED) {
+			countDownLatch.countDown();
+		}
+	}
+}


### PR DESCRIPTION
Spring Batch jobs are executed via Spring Boot's
JobLaunchingCommandLineRunner.  This guide also uses a CommandLineRunner
to verify the results of the job.  This can cause state inconsistencies
between the two (job may run before or after the queries).  This commit
adds a JobExecutionListener that decrements a CountdownLatch.  The
queries wait for the latch to complete guaranteeing that the job has
completed.

Github Issue 8