### PR TITLE
Readme fix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,9 +106,9 @@ include::/complete/src/main/java/hello/BatchConfiguration.java[tag=readerwriterp
 
 The first chunk of code defines the input, processor, and output.
 
-- `reader()` creates an `ItemReader`. It looks for a file called `sample-data.csv` and parses each line item with enough information to turn it into a `Person`.
-- `processor()` creates an instance of our `PersonItemProcessor` you defined earlier, meant to uppercase the data.
-- `write(DataSource)` creates an `ItemWriter`. This one is aimed at a JDBC destination and automatically gets a copy of the dataSource created by `@EnableBatchProcessing`. It includes the SQL statement needed to insert a single `Person` driven by Java bean properties.
+* `reader()` creates an `ItemReader`. It looks for a file called `sample-data.csv` and parses each line item with enough information to turn it into a `Person`.
+* `processor()` creates an instance of our `PersonItemProcessor` you defined earlier, meant to uppercase the data.
+* `write(DataSource)` creates an `ItemWriter`. This one is aimed at a JDBC destination and automatically gets a copy of the dataSource created by `@EnableBatchProcessing`. It includes the SQL statement needed to insert a single `Person` driven by Java bean properties.
 
 The next chunk focuses on the actual job configuration.
 

--- a/README.adoc
+++ b/README.adoc
@@ -103,7 +103,7 @@ Break it down:
 ----
 include::/complete/src/main/java/hello/BatchConfiguration.java[tag=readerwriterprocessor]
 ----
-.
+
 The first chunk of code defines the input, processor, and output.
 - `reader()` creates an `ItemReader`. It looks for a file called `sample-data.csv` and parses each line item with enough information to turn it into a `Person`.
 - `processor()` creates an instance of our `PersonItemProcessor` you defined earlier, meant to uppercase the data.
@@ -116,7 +116,7 @@ The next chunk focuses on the actual job configuration.
 ----
 include::/complete/src/main/java/hello/BatchConfiguration.java[tag=jobstep]
 ----
-.
+
 The first method defines the job and the second one defines a single step. Jobs are built from steps, where each step can involve a reader, a processor, and a writer.
 
 In this job definition, you need an incrementer because jobs use a database to maintain execution state. You then list each step, of which this job has only one step. The job ends, and the Java API produces a perfectly configured job.

--- a/README.adoc
+++ b/README.adoc
@@ -105,6 +105,7 @@ include::/complete/src/main/java/hello/BatchConfiguration.java[tag=readerwriterp
 ----
 
 The first chunk of code defines the input, processor, and output.
+
 - `reader()` creates an `ItemReader`. It looks for a file called `sample-data.csv` and parses each line item with enough information to turn it into a `Person`.
 - `processor()` creates an instance of our `PersonItemProcessor` you defined earlier, meant to uppercase the data.
 - `write(DataSource)` creates an `ItemWriter`. This one is aimed at a JDBC destination and automatically gets a copy of the dataSource created by `@EnableBatchProcessing`. It includes the SQL statement needed to insert a single `Person` driven by Java bean properties.


### PR DESCRIPTION
The official batch-processing [guide](https://spring.io/guides/gs/batch-processing/) had redundant full stops and a broken list. This PR fixes it.