### PR TITLE
Replace deprecated JobCompletionNotificationListener Class with JobExecutionListener

### DIFF
--- a/complete/src/main/java/com/example/batchprocessing/BatchConfiguration.java
+++ b/complete/src/main/java/com/example/batchprocessing/BatchConfiguration.java
@@ -48,7 +48,7 @@ public class BatchConfiguration {
 
 	// tag::jobstep[]
 	@Bean
-	public Job importUserJob(JobRepository jobRepository,Step step1, JobCompletionNotificationListener listener) {
+	public Job importUserJob(JobRepository jobRepository,Step step1, JobExecutionListener listener) {
 		return new JobBuilder("importUserJob", jobRepository)
 			.listener(listener)
 			.start(step1)


### PR DESCRIPTION
JobCompletionNotificationListener is deprecated and replaced by JobExecutionListener. 

In following the tutorial, I had to research this issue