### PR TITLE
Spring Batch JDBC in README.adoc (issue #84)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,14 +19,14 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 [[scratch]]
 == Starting with Spring Initializr
 
-You can use this https://start.spring.io/#!type=maven-project&groupId=com.example&artifactId=batch-processing&name=batch-processing&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.batch-processing&dependencies=batch,hsql[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
+You can use this https://start.spring.io/#!type=maven-project&groupId=com.example&artifactId=batch-processing&name=batch-processing&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.batch-processing&dependencies=batch-jdbc,hsql[pre-initialized project] and click Generate to download a ZIP file. This project is configured to fit the examples in this tutorial.
 
 To manually initialize the project:
 
 . Navigate to https://start.spring.io.
 This service pulls in all the dependencies you need for an application and does most of the setup for you.
 . Choose either Gradle or Maven and the language you want to use. This guide assumes that you chose Java.
-. Click *Dependencies* and select *Spring Batch* and *HyperSQL Database*.
+. Click *Dependencies* and select *Spring Batch JDBC* and *HyperSQL Database*.
 . Click *Generate*.
 . Download the resulting ZIP file, which is an archive of an application that is configured with your choices.
 


### PR DESCRIPTION
README.adoc and link for pre-initialized project refer to "Spring Batch" as depency, however "Spring Batch JDBC" is needed.

Fix for https://github.com/spring-guides/gs-batch-processing/issues/84