### PR TITLE
Fix missing JdbcTemplate in initial project

### DIFF
--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -19,7 +19,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
+			<artifactId>spring-boot-starter-batch-jdbc</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Problem:
The pom.xml files are different in initial and complete folders. After completing all the steps from guide https://spring.io/guides/gs/batch-processing
the initial project fails to start with the error: Parameter 0 of constructor in ...JobCompletionNotificationListener required a bean of type 'JdbcTemplate'

Cause:
The initial project uses spring-boot-starter-batch, which does not include the JDBC auto-configuration. The complete project uses spring-boot-starter-batch-jdbc, which does.

Fix:
This PR replaces the dependency in initial/pom.xml with spring-boot-starter-batch-jdbc to align with the working complete example.